### PR TITLE
fix: multiple money attributes

### DIFF
--- a/lib/buda_active_resource/extensions/money.rb
+++ b/lib/buda_active_resource/extensions/money.rb
@@ -15,10 +15,8 @@ module BudaActiveResource
             ::Money.from_amount(amount.to_f, currency) if amount
           end
 
-          define_method "#{field}=" do |new_amount|
-            amount = new_amount.amount
-            currency = new_amount.currency
-            attributes[:amount] = [amount, currency].map(&:to_s)
+          define_method :"#{field}=" do |amount|
+            attributes[field.to_sym] = amount.presence && [amount.amount, amount.currency.iso_code]
           end
         end
       end


### PR DESCRIPTION
# Contexto
El monetize no funcionaba correctamente cuando había múltiples columnas con el tipo Money. Esto por que, para la monetización, se estaba utilizando :money en lugar del nombre específico de cada columna, lo que hacia que se sobrescribiera el valor por cada columna.

Antes
<img width="675" alt="image" src="https://github.com/user-attachments/assets/b66a12ce-037b-4504-a45b-80d48250b7c7" />

Después
<img width="733" alt="image" src="https://github.com/user-attachments/assets/74894f72-5893-47ae-9ff9-6b8bb378c1a2" />
