### PR TITLE
feat: Add paginated iteration and Ruby 3 ActiveAdmin compatibility

### DIFF
--- a/lib/buda_active_resource/base.rb
+++ b/lib/buda_active_resource/base.rb
@@ -1,5 +1,7 @@
 module BudaActiveResource
   class Base < ::ActiveResource::Base
+    FIND_PER_PAGE = 100
+
     class << self
       threadsafe_attribute :_buda_site, :_agent_id, :_agent_secret
 
@@ -61,6 +63,38 @@ module BudaActiveResource
 
     def self.find_by(arg, *_args)
       find(arg[primary_key])
+    end
+
+    def self.find_each(params = {}, &block) # rubocop:disable Metrics/MethodLength
+      return enum_for(__method__, params) unless block
+
+      page = 1
+
+      loop do
+        result = retry_on_error error_class: Net::ReadTimeout do
+          find(
+            :all, params: {
+              page: page,
+              per: FIND_PER_PAGE
+            }.merge(params)
+          )
+        end
+
+        pagination_info = format.pagination_info
+
+        result.each(&block)
+
+        break if pagination_info['total_pages'] <= page
+
+        page += 1
+      end
+    end
+
+    def self.retry_on_error(retries: 5, error_class: StandardError)
+      retries -= 1
+      yield
+    rescue error_class
+      retry unless retries.negative?
     end
   end
 end

--- a/lib/buda_active_resource/extensions/active_admin_resource.rb
+++ b/lib/buda_active_resource/extensions/active_admin_resource.rb
@@ -8,14 +8,16 @@ module BudaActiveResource
           find(_id)
         end
 
-        def process_active_admin_collection_query(ransack:, reorder:, page:, per:)
+        def process_active_admin_collection_query(options = {}, **kwargs)
+          options = options.merge(kwargs)
+
           collection = find(
             :all,
             params: {
-              search: ransack,
-              order: reorder,
-              page: page,
-              per: per
+              search: options[:ransack] || {},
+              order: options[:reorder],
+              page: options[:page],
+              per: options[:per]
             }
           )
 


### PR DESCRIPTION
### Summary
Adds paginated iteration support to BudaActiveResource::Base and improves ActiveAdmin query compatibility across Ruby versions.
- Adds FIND_PER_PAGE, find_each, and retry_on_error to support batch-style iteration over remote ActiveResource collections.
- Updates process_active_admin_collection_query to accept both positional option hashes and keyword arguments, supporting Ruby 2.7 and Ruby 3+ call behavior.

